### PR TITLE
Add `software.amazon.awssdk:bom`

### DIFF
--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -1,2 +1,3 @@
 aws-java-sdk
+software.amazon.awssdk:bom
 netty-bom


### PR DESCRIPTION
`aws.sdk.version` and `software.amazon.awssdk:bom` both update with the same frequency so should be processed together.

Of note - `software.amazon.awssdk:bom` regularly do minor (not patch) updates which will not be automerged in this actions' current form.