### PR TITLE
Automatically upgrade test framework dependencies

### DIFF
--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -1,5 +1,5 @@
 aws-java-sdk
 software.amazon.awssdk:bom minor
 netty-bom
-junit minor
-assertj minor
+org.junit:junit-bom minor
+org.assertj:assertj-core minor

--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -1,3 +1,5 @@
 aws-java-sdk
 software.amazon.awssdk:bom minor
 netty-bom
+junit minor
+assertj minor


### PR DESCRIPTION
Test frameworks (eg JUnit, AssertJ) should be safe to upgrade as issues would only affect the test execution, a requirement for the PR to be approved.