### PR TITLE
 Add `testcontainers` to automerge whitelist

### DIFF
--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -3,3 +3,5 @@ software.amazon.awssdk:bom minor
 netty-bom
 org.junit:junit-bom minor
 org.assertj:assertj-core minor
+com.adobe.testing:s3mock-testcontainers minor
+org.testcontainers:testcontainers-bom minor


### PR DESCRIPTION
`testcontainers` are only ever test dependencies.

Therefore the tests are enough to tell us if they are safe to merge.