### PR TITLE
Add Google Cloud libraries to automerge whitelist

### DIFF
--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -1,5 +1,7 @@
 aws-java-sdk
 software.amazon.awssdk:bom minor
+com.google.cloud:libraries-bom minor
+com.google.api-client:google-api-client minor
 netty-bom
 org.junit:junit-bom minor
 org.assertj:assertj-core minor


### PR DESCRIPTION
If we're ok with AWS' cloud libraries being merged automatically, we should be happy to do the same for Google, too.