### PR TITLE
Add `wiremock` to automerge whitelist

### DIFF
--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -5,5 +5,4 @@ org.junit:junit-bom minor
 org.assertj:assertj-core minor
 com.adobe.testing:s3mock-testcontainers minor
 org.testcontainers:testcontainers-bom minor
-org.testcontainers:testcontainers-bom minor
 org.wiremock:wiremock-standalone minor

--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -5,3 +5,5 @@ org.junit:junit-bom minor
 org.assertj:assertj-core minor
 com.adobe.testing:s3mock-testcontainers minor
 org.testcontainers:testcontainers-bom minor
+org.testcontainers:testcontainers-bom minor
+org.wiremock:wiremock-standalone minor


### PR DESCRIPTION
It's a mocking/test dependency, will be covered by tests