### PR TITLE
Auto merge `hamcrest`

### DIFF
--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -8,3 +8,4 @@ org.assertj:assertj-core minor
 com.adobe.testing:s3mock-testcontainers minor
 org.testcontainers:testcontainers-bom minor
 org.wiremock:wiremock-standalone minor
+org.hamcrest:hamcrest-core minor


### PR DESCRIPTION
`hamcrest` is a unit testing dependency, so we can assume it’s safe to upgrade if the tests pass.