### PR TITLE
Auto merge `checker-qual`

### DIFF
--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -9,3 +9,4 @@ com.adobe.testing:s3mock-testcontainers minor
 org.testcontainers:testcontainers-bom minor
 org.wiremock:wiremock-standalone minor
 org.hamcrest:hamcrest-core minor
+org.checkerframework:checker-qual minor


### PR DESCRIPTION
[`checker-qual`](https://mvnrepository.com/artifact/org.checkerframework/checker-qual) is a test-only dependency and [frequently updated](https://github.com/hazelcast/hazelcast-mono/pulls?q=is%3Apr+%22Bump+org.checkerframework%3Achecker-qual%22)