### PR TITLE
Auto merge `hazelcast-wm`

### DIFF
--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -11,3 +11,4 @@ org.wiremock:wiremock-standalone minor
 org.hamcrest:hamcrest-core minor
 org.checkerframework:checker-qual minor
 nl.jqno.equalsverifier:equalsverifier minor
+com.hazelcast:hazelcast-wm minor


### PR DESCRIPTION
We can assume that the latest Hazelcast dependency is safe to use.