### PR TITLE
Add `cooldown` Dependabot configuration to limit minimum age of NPM/GitHub-Actions dependencies [DI-776]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
See https://github.com/hazelcast/hazelcast-mono/pull/5738

Adding configuration to _every_ repository that has some kind of auto-merge Dependabot action.

Fixes: [DI-776](https://hazelcast.atlassian.net/browse/DI-776)

[DI-776]: https://hazelcast.atlassian.net/browse/DI-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ