### PR TITLE
Use centralised Slack notification to avoid (deprecated) `8398a7/action-slack`

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -35,6 +35,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_AUTOMERGING }}
       - uses: hazelcast/docker-actions/slack-notification@master
+        if: failure()
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_FOR_AUTOMERGING }}
           slack-channel: "#dependabot-notifications"

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -34,11 +34,7 @@ jobs:
           .github/workflows/dependabot-automerge.sh "$PR_URL" "$DEPENDENCY_NAMES" "$UPDATE_TYPE"
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_AUTOMERGING }}
-      - uses: 8398a7/action-slack@v3
-        if: failure()
+      - uses: hazelcast/docker-actions/slack-notification@master
         with:
-          fields: repo,message,author,action,eventName,workflow,job,pullRequest
-          status: ${{ job.status }}
-          channel: "#dependabot-notifications"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_FOR_AUTOMERGING }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_FOR_AUTOMERGING }}
+          slack-channel: "#dependabot-notifications"

--- a/.github/workflows/publish-readme.yaml
+++ b/.github/workflows/publish-readme.yaml
@@ -31,6 +31,7 @@ jobs:
           user: ${{ env.GOOGLE_DEVOPSHAZELCAST_EMAIL }}
           token: ${{ env.CONFLUENCE_DEVOPSHAZELCAST_API_TOKEN }}
       - uses: hazelcast/docker-actions/slack-notification@master
+        if: failure()
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_FOR_AUTOMERGING }}
           slack-channel: "#dependabot-notifications"

--- a/.github/workflows/publish-readme.yaml
+++ b/.github/workflows/publish-readme.yaml
@@ -30,11 +30,7 @@ jobs:
           cloud: hazelcast
           user: ${{ env.GOOGLE_DEVOPSHAZELCAST_EMAIL }}
           token: ${{ env.CONFLUENCE_DEVOPSHAZELCAST_API_TOKEN }}
-      - uses: 8398a7/action-slack@v3
-        if: failure()
+      - uses: hazelcast/docker-actions/slack-notification@master
         with:
-          fields: all
-          status: ${{ job.status }}
-          channel: "#dependabot-notifications"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_FOR_AUTOMERGING }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_FOR_AUTOMERGING }}
+          slack-channel: "#dependabot-notifications"


### PR DESCRIPTION
The action is now archived - https://github.com/8398a7/action-slack - "use at own risk".

Update to use `docker-actions` implementations to remove explicit references to `8398a7/action-slack`.

Fixes: [DI-767](https://hazelcast.atlassian.net/browse/DI-767)

[DI-767]: https://hazelcast.atlassian.net/browse/DI-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ