### PR TITLE
Update AWS policy to patch

### DIFF
--- a/.github/workflows/default-dependabot-automerge-whitelist.conf
+++ b/.github/workflows/default-dependabot-automerge-whitelist.conf
@@ -1,5 +1,5 @@
 aws-java-sdk
-software.amazon.awssdk:bom minor
+software.amazon.awssdk:bom patch
 com.google.cloud:libraries-bom minor
 com.google.api-client:google-api-client minor
 netty-bom


### PR DESCRIPTION
Update AWS policy to patch to reflect the fact, that some dependency update may make exclusions unncessary in core Hazelcast 

See https://github.com/hazelcast/hazelcast-mono/pull/6370#discussion_r3059621606